### PR TITLE
Fixes to work with newer autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,14 +8,9 @@ AC_PROG_CC
 CPPFLAGS="$CPPFLAGS -Wall `getconf LFS_CFLAGS`"
 LDFLAGS="$LDFLAGS `getconf LFS_LDFLAGS`"
 
-AC_CHECK_LIB([fuse], [fuse_main], , AC_MSG_ERROR([Unable to find libfuse]))
+PKG_CHECK_MODULES([FUSE], [fuse >= 2.5])
 
 AC_HEADER_STDC
-AC_CHECK_HEADER([fuse/fuse.h], , AC_MSG_ERROR([Unable to find fuse.h]))
-AC_PREPROC_IFELSE(
-[#define FUSE_USE_VERSION 25
-#include <fuse.h>]
-, , AC_MSG_ERROR([You need FUSE version 2.5.x]))
 
 AC_C_CONST
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([xbfuse], [1.0], [mike@multimedia.cx])
-AM_INIT_AUTOMAKE([1.11])
+AM_INIT_AUTOMAKE([1.11 foreign])
 AC_CONFIG_HEADER([src/config.h])
 
 AC_PROG_CC

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([xbfuse], [1.0], [mike@multimedia.cx])
-AM_INIT_AUTOMAKE([xbfuse], [1.0])
+AM_INIT_AUTOMAKE([1.11])
 AC_CONFIG_HEADER([src/config.h])
 
 AC_PROG_CC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,5 @@
 bin_PROGRAMS = xbfuse
 xbfuse_SOURCES = tree.c xdvdfs.c main.c
 noinst_HEADERS = tree.h xdvdfs.h
+xbfuse_CFLAGS = $(CFLAGS) $(FUSE_CFLAGS)
+xbfuse_LDFLAGS = $(LDFLAGS) $(FUSE_LDFLAGS) $(FUSE_LIBS)


### PR DESCRIPTION
Also included is a commit to use pkgconfig to find fuse. I decided to refrain from updating the rEADME, in case you still prefer to recommend the use of a single gcc command-line for building the binary. Happy to add something as part of this pull if you prefer.